### PR TITLE
dns-digitalocean: Ignore SOA TTL in favor of explicit TTL argument

### DIFF
--- a/certbot-dns-digitalocean/certbot_dns_digitalocean/_internal/dns_digitalocean.py
+++ b/certbot-dns-digitalocean/certbot_dns_digitalocean/_internal/dns_digitalocean.py
@@ -82,6 +82,7 @@ class _DigitalOceanClient:
 
         try:
             domain = self._find_domain(domain_name)
+            domain.ttl = None
         except digitalocean.Error as e:
             hint = None
 


### PR DESCRIPTION
I was having trouble with DigitalOcean's DNS validation in the latest Certbot Docker image. Even though Let's Encrypt validation server ignores DNS TTL values, LE would still see old, long-gone TXT values as DO's internal DNS [caches records](https://github.com/certbot/certbot/issues/8161#issuecomment-704712041).

This means that when using DigitalOcean's DNS, the TTL value of the validation TXT records _actually matter_ and this TTL is by default quite high. A—what now seems partial—fix has been merged in the past:

`.add_txt_record()` passes a TTL of 30 introduced in [this merged pull request](https://github.com/certbot/certbot/pull/8693) to `python-digitalocean`. That package, however, [prefers the value set in `self.ttl`](https://github.com/koalalorenzo/python-digitalocean/blob/ebea58fddf2ceea35c027bfa66f2fa9f5debfd64/digitalocean/Domain.py#L83) over the 30-second-kwargs argument. I could see this happen in the logs:

```
DEBUG:digitalocean:POST https://api.digitalocean.com/v2/domains/example.com/records data:{
  'type': 'TXT', 
  'name': '_acme-challenge', 
  'data': '......', 
  'ttl': 1800
} {
  'Content-type': 'application/json', 
  'Authorization': 'Bearer TOKEN0', 
  'User-Agent': 'python-digitalocean/1.16.0 requests/2.26.0'
} None
```

_(Formatted for readability; note the TTL)_

## Why this happens

`add_txt_record()` calls `_find_domain()` which returns variable `domain` that has its `.ttl` property set 1800, which matches the SOA record:

```
$ dig example.com soa +short
ns1.digitalocean.com. hostmaster.example.com. 1640093408 10800 3600 604800 1800
```

`domain` is then used for creating a new record, leading to the issue: the 30-second argument is ignored in favor of the much higher value, 1800. 

## Fix

Setting `domain.ttl=None` fixes this issue. In logs, `dig` and DO's DNS web interface the correct value of 30 will be seen as nothing overrides it anymore. DigitalOcean's internal DNS cache honors the TTL and will purge the records after 30 seconds. Not quite 0, but much better than 1800 seconds.

## Users of `python-digitalocean < 1.15` (that have no support for the `ttl` kwargs)

The TTL field is optional in DigitalOcean's API so there should be no change. When `self.ttl` is `None`, the TTL will default to 1800, rather than be explicitly set to it.

## When do you encounter this behavior?

When you issue a certificate, TXT records are added via the API. When you then create a new certificate that doesn't re-use the previous validation tokens (by, for example, deleting the Docker volumes & starting from scratch) within 1800 seconds, new TXT records are added (you can see them in the web interface) but not always served by DO's DNS server, rather, old records are returned, even when using `dig @ns1.digitalocean.com _acme-challenge.example.com TXT`.

---

As this is my first contribution to a non-internal project; I appreciate any feedback.